### PR TITLE
Only find files that AniDB track

### DIFF
--- a/sample.sh
+++ b/sample.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-find "${@}" -type f -exec edonkey-tool-hash "{}" ";" |
+find "${@}" -type f \( -name *.mkv -o -name *.avi -o -name *.mp4 \) -exec edonkey-tool-hash "{}" ";" |
 while read hash
 do
 	echo "${hash}"


### PR DESCRIPTION
Since my folders usually include a lot of extreneous files, there's no point in hashing stuff AniDB doesn't support - so this change to find only runs edonkey-hash-tool on the files AniDB works on.